### PR TITLE
Enabble archives and printer management; add Archives Location tag

### DIFF
--- a/configuration/globalproperties/gp_ces.xml
+++ b/configuration/globalproperties/gp_ces.xml
@@ -25,5 +25,10 @@
             <property>log.level</property>
             <value>org.openmrs.api:info</value>
         </globalProperty>
+        <globalProperty>
+            <property>emr.paperRecordIdentifierType</property>
+            <!-- Patient Identifier: Expediente -->
+            <value>9124b296-d14d-4222-862d-44867e728812</value>
+        </globalProperty>
     </globalProperties>
 </config>

--- a/configuration/pih/pih-config-mexico-demo.json
+++ b/configuration/pih/pih-config-mexico-demo.json
@@ -8,6 +8,35 @@
   "primaryIdentifierPrefix": "DEM",
   "providerIdentifierPrefix": "DEM",
 
+  "components": [
+    "allergies",
+    "ancProgram",
+    "archives",
+    "asthmaProgram",
+    "bmiOnClinicianDashboard",
+    "chwApp",
+    "clinicianDashboard",
+    "dataExports",
+    "diabetesProgram",
+    "epilepsyProgram",
+    "hypertensionProgram",
+    "malnutritionProgram",
+    "managePrinters",
+    "mentalHealthProgram",
+    "myAccount",
+    "overviewReports",
+    "patientDocuments",
+    "patientRegistration",
+    "primaryCare",
+    "programs",
+    "providerRelationships",
+    "relationships",
+    "systemAdministration",
+    "todaysVisits",
+    "visitManagement",
+    "vitals"
+  ],
+  
   "locationTags": {
     "Login Location": [
       "Hospital",

--- a/configuration/pih/pih-config-mexico.json
+++ b/configuration/pih/pih-config-mexico.json
@@ -6,7 +6,6 @@
   "components": [
     "allergies",
     "ancProgram",
-    "archives",
     "asthmaProgram",
     "bmiOnClinicianDashboard",
     "chwApp",
@@ -16,7 +15,6 @@
     "epilepsyProgram",
     "hypertensionProgram",
     "malnutritionProgram",
-    "managePrinters",
     "mentalHealthProgram",
     "myAccount",
     "overviewReports",

--- a/configuration/pih/pih-config-mexico.json
+++ b/configuration/pih/pih-config-mexico.json
@@ -6,6 +6,7 @@
   "components": [
     "allergies",
     "ancProgram",
+    "archives",
     "asthmaProgram",
     "bmiOnClinicianDashboard",
     "chwApp",
@@ -15,6 +16,7 @@
     "epilepsyProgram",
     "hypertensionProgram",
     "malnutritionProgram",
+    "managePrinters",
     "mentalHealthProgram",
     "myAccount",
     "overviewReports",
@@ -39,6 +41,7 @@
     "shortcutField": "cityVillage"
   },
   "locationTags": {
+    "Archives Location": ["CES Oficina"],
     "Identifier Assignment Location": ["Chiapas"],
     "Consult Note Location": ["Hospital", "CES Oficina", "Casa Materna", "CER", "Capitan", "Honduras", "Laguna del Cofre", "Letrero", "Matazano", "Plan Alta", "Plan Baja", "Reforma", "Salvador", "Soledad"],
     "Registration Location": ["Hospital", "CES Oficina", "Casa Materna", "CER", "Capitan", "Honduras", "Laguna del Cofre", "Letrero", "Matazano", "Plan Alta", "Plan Baja", "Reforma", "Salvador", "Soledad"],


### PR DESCRIPTION
https://pihemr.atlassian.net/browse/MEX-498

Unfortunately I'm not sure there's any way to commit this for testing without it being staged for release. Next release is next week (about Feb 4).

Doesn't work quite as hoped.

![Peek 2021-01-29 18-41](https://user-images.githubusercontent.com/1031876/106345000-e8156c80-6261-11eb-8b69-29a897cd862c.gif)

All the other buttons (Patient Documents & the home page Archives button) work as expected.