### PR TITLE
Enable SPA Preview for ces-ci

### DIFF
--- a/configuration/pih/pih-config-mexico-demo.json
+++ b/configuration/pih/pih-config-mexico-demo.json
@@ -32,6 +32,7 @@
     "programs",
     "providerRelationships",
     "relationships",
+    "spaPreview",
     "systemAdministration",
     "todaysVisits",
     "visitManagement",


### PR DESCRIPTION
Esta añade butones de "preview nuevo applicacion" a las paginas de Home y Patient Chart. Deja que puedes ver el Patient Chart nuevo ("frontend 3.0" / "microfrontends") por cualquier paciente. Solo en el servidor de CI.