### PR TITLE
Upgrade packager-maven-plugin to 1.6.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
             <plugin>
                 <groupId>org.openmrs.maven.plugins</groupId>
                 <artifactId>openmrs-packager-maven-plugin</artifactId>
-                <version>1.4.0</version>
+                <version>1.6.0-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>generate-resource-filters</id>


### PR DESCRIPTION
This version contains https://github.com/openmrs/openmrs-contrib-packager-maven-plugin/commit/903084b8e8825f0c41c039f38e3c1d9773b3e570 , which CES depends on.