### PR TITLE
UHM-6440: Remove Check-In and Vital Signs app from home page

### DIFF
--- a/configuration/pih/pih-config-mexico-demo.json
+++ b/configuration/pih/pih-config-mexico-demo.json
@@ -1,5 +1,5 @@
 {
-  
+
   "welcomeMessage": "EMR de Compañeros en Salud - Demo",
   "browserWarning": "Por favor utiliza <b>Google Chrome</b> como navagador",
 
@@ -36,9 +36,10 @@
     "systemAdministration",
     "todaysVisits",
     "visitManagement",
-    "vitals"
+    "vitals",
+    "vitalsHomepageApp"
   ],
-  
+
   "locationTags": {
     "Login Location": [
       "Hospital",
@@ -48,3 +49,7 @@
     ]
   }
 }
+[
+
+
+]

--- a/configuration/pih/pih-config-mexico.json
+++ b/configuration/pih/pih-config-mexico.json
@@ -28,7 +28,8 @@
     "systemAdministration",
     "todaysVisits",
     "visitManagement",
-    "vitals"
+    "vitals",
+    "vitalsHomepageApp"
   ],
   "scheduleBackupReports": "false",
   "dashboardUrl": "/coreapps/clinicianfacing/patient.page?patientId={{patientId}}&app=pih.app.clinicianDashboard",


### PR DESCRIPTION
@Joseph-Developer We recently made a chance to the PIH EMR components so that the VItals Home Page app could be turned off, while keep the Vitals form on... to do this, we moved the Vitals Home Page app into a different component. This PR just makes sure that the Vitals Home Page app stays on for the Mexico.... *however* I hear from @brandones  that in Mexico you don't really use the Vitals Home Page app and may actually want to turn it off... in that case, we can close this PR without merging.
